### PR TITLE
feat: optional tags to specify authentication and context requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,31 @@ Client applications must check the accepts tag for their protocol and ensure tha
 
 When sending a POST to the Frame Server, client applications must include the `clientProtocol` used to generate the payload, which will allow the Frame server to know what data is available and how to verify the `trustedData.messageBytes`.
 
+### Convention for unauthenticated frames
+
+If a Frame Server does not require authentication, it should advertise that it accepts the `anonymous` client protocol with version `1.0`. This allows clients to send `POST` requests without needing to sign the payload. All clients should be able to send requests to unauthenticated Frame Servers.
+
+```html
+<meta property="of:accepts:anonymous" content="1.0" />
+```
+
+Clients sending POST requests to an unauthenticated Frame Server should include the `clientProtocol` as `anonymous@1.0` and should not include a `trustedData.messageBytes` field in the POST payload.
+
+Here is an example of a POST payload to an unauthenticated Frame Server:
+
+```
+{
+  "clientProtocol": "anonymous@1.0",
+  "untrustedData": {
+    "url": "https://example.com/frame",
+    "unixTimestamp": 1645382400000,
+    "buttonIndex": 1,
+    "inputText": "...",
+    "state": "..."
+  }
+}
+```
+
 ## `POST` Payloads
 
 When a user clicks a button on a Frame, the Frame developer receives a `POST` request with a payload containing both `untrustedData` and `trustedData`. The `trustedData.messageBytes`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To turn your web pages into Frames, you need to add basic metadata to your page.
 | `of:image` | An image which should have an aspect ratio of `1.91:1` or `1:1`.  |
 | `og:image` | An image which should have an aspect ratio of `1.91:1`. Fallback for clients that do not support frames. |
 
-The tag `of:accepts:anonyous` identifies that an Open Frame does not require authentication, and thus can be rendered by any Open Frame compatible client.
+The tag `of:accepts:anonymous` identifies that an Open Frame does not require authentication, and thus can be rendered by any Open Frames compatible client.
 
 ### Optional properties
 
@@ -47,7 +47,6 @@ The tag `of:accepts:anonyous` identifies that an Open Frame does not require aut
 | `of:image:aspect_ratio` | The aspect ratio of the image specified in the `of:image` field. Allowed values are `1.91:1` and `1:1`. Default: `1.91:1` |
 | `of:image:alt` | Alt text associated with the image for accessibility |
 | `of:state` | A state serialized to a string (for example via JSON.stringify()). Maximum 4096 bytes. Will be ignored if included on the initial frame |
-| `of:context:$protocol_identifier` | Boolean value specifying whether requests sent to frame server must include context (untrustedData) corresponding to the client protocol. Default = `true` | 
 
 ## Button actions
 
@@ -204,7 +203,5 @@ type FramesPost = {
 ```
 
 Different client protocols may choose to include additional fields in the `untrustedData` and `trustedData` portions of the POST payload. Frame Servers may use the `clientProtocol` as a hint for what additional fields are available. All client protocols must include at least the common fields defined above.
-
-The `of:context:$protocol_identifier` tag specifies whether it is required for a POST payload to include additional fields for the specified `clientProtocol`. If the context value is `true` or not provided, then any request to the Frame Server must include the `untrustedData` data fields for the `clientProtocol`. If the context value for a `clientProtocol` is `false` or `of:context:none` is present, then Frame server can accept requests with no additional fields required.
 
 While the payload is similar to the [Farcaster Frames Spec](https://docs.farcaster.xyz/reference/frames/spec), it differs in two important ways. The first is the addition of the `clientProtocol` field. The second is that in place of a `timestamp`, which in Farcaster is the number of seconds since the Farcaster epoch, Open Frames uses the `unixTimestamp` field which is the number of seconds since the unix epoch.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To turn your web pages into Frames, you need to add basic metadata to your page.
 | `of:image` | An image which should have an aspect ratio of `1.91:1` or `1:1`.  |
 | `og:image` | An image which should have an aspect ratio of `1.91:1`. Fallback for clients that do not support frames. |
 
+The tag `of:accepts:anonyous` identifies that an Open Frame does not require authentication, and thus can be rendered by any Open Frame compatible client.
+
 ### Optional properties
 
 | Property | Description |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We expect the Open Frames specification to evolve, both through improvements to 
 
 ### Client Application
 
-Client applications are responsible for rendering Frames for end-users, handling interactions with buttons on Frames, and creating the POST payload to be sent to the Frames Server. Client applications can support one or more `clientProtocols`.
+Client applications are responsible for rendering Frames for end-users, handling interactions with buttons on Frames, and creating the POST payload to be sent to the Frames Server. Client applications must support one or more `clientProtocols`.
 
 ### Frames Server
 
@@ -28,6 +28,7 @@ To turn your web pages into Frames, you need to add basic metadata to your page.
 | Property | Description |
 | --- | --- |
 | `of:version`  | The version label of the Open Frames spec. Currently the only supported version is `vNext` |
+| `of:accepts:$protocol_identifier` | The minimum client protocol version accepted for the given protocol identifier. For example `vNext` , or `1.5`. At least one `$protocol_identifier` must be specified. |
 | `of:image` | An image which should have an aspect ratio of `1.91:1` or `1:1`.  |
 | `og:image` | An image which should have an aspect ratio of `1.91:1`. Fallback for clients that do not support frames. |
 
@@ -35,8 +36,6 @@ To turn your web pages into Frames, you need to add basic metadata to your page.
 
 | Property | Description |
 | --- | --- |
-| `of:accepts:$protocol_identifier` | The minimum client protocol version accepted for the given protocol identifier. For example `vNext` , or `1.5`. At least one `$protocol_identifier` must be specified if `of:authenticated` is specified as `true` or `optional`. |
-| `of:authenticated` | String value specifying whether frame server is requesting an authenticated response. Allowed values are `true`, `false`, or `optional`. Default: `true` if client protocol is present, `false` otherwise |
 | `of:button:$idx` | 256 byte string containing the user-visible label for button at index `$idx`. Buttons are 1-indexed. Maximum 4 buttons per Frame. `$idx` values must be rendered in an unbroken sequence.   |
 | `of:button:$idx:action` | Valid options are `post`, `post_redirect`, `mint`, `link`, and `tx`. Default: `post` |
 | `of:button:$idx:target` | The target of the action. For `post` , `post_redirect`, and link action types the target is expected to be a URL starting with `http://` or `https://`. For the mint action type the target must be a [CAIP-10 URL](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md) |
@@ -46,6 +45,7 @@ To turn your web pages into Frames, you need to add basic metadata to your page.
 | `of:image:aspect_ratio` | The aspect ratio of the image specified in the `of:image` field. Allowed values are `1.91:1` and `1:1`. Default: `1.91:1` |
 | `of:image:alt` | Alt text associated with the image for accessibility |
 | `of:state` | A state serialized to a string (for example via JSON.stringify()). Maximum 4096 bytes. Will be ignored if included on the initial frame |
+| `of:context:$protocol_identifier` | Boolean value specifying whether requests sent to frame server must include context (untrustedData) corresponding to the client protocol. Default = `true` | 
 
 ## Button actions
 
@@ -167,6 +167,8 @@ Frames Servers that wish to handle both Farcaster and Open Frames interactions a
 />
 ```
 
+If a frame does not require authentication from any client protocol, the frame can include the tag `of:accepts:anonymous`. If the anonymous tag is included with other client protocol tags, then it is optional for a request to this Frame Server to include authentication for the other client protocol(s).
+
 If a Frame Server declares that it is compatible with a client protocol, Client Applications capable of sending POST responses using that protocol should feel confident that the Frame will work as expected.
 
 Client protocol strings must conform to the following format: `$PROTOCOL_IDENTIFIER@$PROTOCOL_VERSION`. Protocol versions are a string, and it is up to each protocol to decide how it should specify versions. For example, a Farcaster client today might define it’s `clientProtocol` as `farcaster@vNext`. 
@@ -176,29 +178,16 @@ The version specified in the `of:accepts:*` tag should be the earliest version o
 Client applications must check the accepts tag for their protocol and ensure that they are capable of sending POST payloads in a format that the Frame Server can understand. If the
 `of:accepts:$client_protocol` field is absent, client applications may choose to assume that the Frame Server only accepts requests using the Farcaster request format using the version specified in the `fc:frame` meta tag. If the client application does not support any of the listed client protocols, the client can choose to skip rendering the Frame entirely or show the Frame with the buttons disabled.
 
-When sending a POST to the Frame Server containing `trustedData`, client applications must include the `clientProtocol` used to generate the payload, which will allow the Frame server to know what data is available and how to verify the `trustedData.messageBytes`.
-
-## Authenticated Identifier
-
-`authenticated` is a tag exposed by Frames that specifies the type of request that a Frame Server is capable of receiving. The value of `authenticated` must not be changed throughout a Frame session to provide consistency for client applications.
-
-There are three possible values:
-- `true` : client application must send a `POST` request with a payload containing `trustedData` that corresponds to the `clientProtocol` of the request
-- `false` : client application is not required to contain `trustedData` or `clientProtocol` in `POST` request payload
-- `optional` : client application should send `POST` request with a payload contained `trustedData` if user is logged into a session of a `clientProtocol`
-
-When a Frame appears in an application feed, the application should decide to render the frame based on the following criteria:
-- If `of:authenticated` is `false` or `optional`, Frame can be displayed if the application supports the minimum `of:version` of the Frame
-- If `of:authenticated` is `true`, Frame can be displayed if application supports one of the minimum `of:accepts:$client_protocol` versions and the application has a user logged into a session of `$client_protocol`
+When sending a POST to the Frame Server, client applications must include the `clientProtocol` used to generate the payload, which will allow the Frame server to know what data is available and how to verify the `trustedData.messageBytes`.
 
 ## `POST` Payloads
 
-When a user clicks a button on a Frame, the Frame developer receives a `POST` request with a payload containing both `untrustedData` and optional `trustedData`. The `trustedData.messageBytes`
+When a user clicks a button on a Frame, the Frame developer receives a `POST` request with a payload containing both `untrustedData` and `trustedData`. The `trustedData.messageBytes`
 can be verified by Frame developers so that they can provably know that the contents of that payload were signed by a given user. We propose a minimum schema for all `POST` payloads that can be implemented by any Open Frames `clientProtocol`.
 
 ```tsx
 type FramesPost = {
-  clientProtocol?: string; // The client protcol used by the client to generate the payload
+  clientProtocol: string; // The client protcol used by the client to generate the payload
   untrustedData: {
     url: string; // The URL of the Frame that was clicked. May be different from the URL that the data was posted to.
     unixTimestamp: number; // Unix timestamp in milliseconds
@@ -206,12 +195,14 @@ type FramesPost = {
     inputText?: string; // Input text for the Frame's text input, if present. Undefined if no text input field is present
     state?: string; // State that was passed from the frame, passed back to the frame, serialized to a string. Max 4kB.q
   };
-  trustedData?: {
+  trustedData: {
     messageBytes: string;
   };
 };
 ```
 
 Different client protocols may choose to include additional fields in the `untrustedData` and `trustedData` portions of the POST payload. Frame Servers may use the `clientProtocol` as a hint for what additional fields are available. All client protocols must include at least the common fields defined above.
+
+The `of:context:$protocol_identifier` tag specifies whether it is required for a POST payload to include additional fields for the specified `clientProtocol`. If the context value is `true` or not provided, then any request to the Frame Server must include the `untrustedData` data fields for the `clientProtocol`. If the context value for a `clientProtocol` is `false` or `of:context:none` is present, then Frame server can accept requests with no additional fields required.
 
 While the payload is similar to the [Farcaster Frames Spec](https://docs.farcaster.xyz/reference/frames/spec), it differs in two important ways. The first is the addition of the `clientProtocol` field. The second is that in place of a `timestamp`, which in Farcaster is the number of seconds since the Farcaster epoch, Open Frames uses the `unixTimestamp` field which is the number of seconds since the unix epoch.

--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ Frames Servers that wish to handle both Farcaster and Open Frames interactions a
 />
 ```
 
-If a frame does not require authentication from any client protocol, the frame can include the tag `of:accepts:anonymous`. If the anonymous tag is included with other client protocol tags, then it is optional for a request to this Frame Server to include authentication for the other client protocol(s).
-
 If a Frame Server declares that it is compatible with a client protocol, Client Applications capable of sending POST responses using that protocol should feel confident that the Frame will work as expected.
 
 Client protocol strings must conform to the following format: `$PROTOCOL_IDENTIFIER@$PROTOCOL_VERSION`. Protocol versions are a string, and it is up to each protocol to decide how it should specify versions. For example, a Farcaster client today might define it’s `clientProtocol` as `farcaster@vNext`. 
@@ -205,6 +203,8 @@ Here is an example of a POST payload to an unauthenticated Frame Server:
   }
 }
 ```
+
+If the anonymous tag is included with other client protocol tags, then it is optional for a request to this Frame Server to include authentication for the other client protocol(s).
 
 ## `POST` Payloads
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The version specified in the `of:accepts:*` tag should be the earliest version o
 Client applications must check the accepts tag for their protocol and ensure that they are capable of sending POST payloads in a format that the Frame Server can understand. If the
 `of:accepts:$client_protocol` field is absent, client applications may choose to assume that the Frame Server only accepts requests using the Farcaster request format using the version specified in the `fc:frame` meta tag. If the client application does not support any of the listed client protocols, the client can choose to skip rendering the Frame entirely or show the Frame with the buttons disabled.
 
-When sending a POST to the Frame Server contained `trustedData`, client applications must include the `clientProtocol` used to generate the payload, which will allow the Frame server to know what data is available and how to verify the `trustedData.messageBytes`.
+When sending a POST to the Frame Server containing `trustedData`, client applications must include the `clientProtocol` used to generate the payload, which will allow the Frame server to know what data is available and how to verify the `trustedData.messageBytes`.
 
 ## Authenticated Identifier
 
@@ -97,11 +97,11 @@ When sending a POST to the Frame Server contained `trustedData`, client applicat
 There are three possible values:
 - `true` : client application must send a `POST` request with a payload containing `trustedData` that corresponds to the `clientProtocol` of the request
 - `false` : client application is not required to contain `trustedData` or `clientProtocol` in `POST` request payload
-- `optional` : client application should send `POST` request with a payload contained `trustedData` is user is logged into a session of a `clientProtocol`
+- `optional` : client application should send `POST` request with a payload contained `trustedData` if user is logged into a session of a `clientProtocol`
 
 When a Frame appears in an application feed, the application should decide to render the frame based on the following criteria:
 - If `of:authenticated` is `false` or `optional`, Frame can be displayed if the application supports the minimum `of:version` of the Frame
-- If `of:authenticated` is `true`, Frame can be displayed if application supports one of the minimum `of:accepts:$client_protocol` versions of the Frame and the application has a user logged into a session of `$client_protocol`
+- If `of:authenticated` is `true`, Frame can be displayed if application supports one of the minimum `of:accepts:$client_protocol` versions and the application has a user logged into a session of `$client_protocol`
 
 ## `POST` Payloads
 


### PR DESCRIPTION
This pull request makes the following changes:
- Add an additional client protocol option `of:accepts:anonymous` that signals to client applications that authenticated requests are not required
- Add new optional tag `of:context:$client_protocol` that is true or false and specifies whether additional context (untrustedData fields that extend OpenFrames) are required for a particular `$client_protocol`. There is also an option to pass `of:context:none` that signals to client applications that there is no additional context required. 

The motivation for this spec change is to allow frames to support "unauthenticated" and "optionally authenticated" sessions. This allows open frames to be displayed across a wider variety of client applications, and gives more flexibility to frames and applications to decide their requirements for displaying frames and policies for user privacy.

 ## What are the advantages of allowing frames to specify their expected level of authentication?

There are a lot of frames where there isn't a strict requirement to verify the identity of the user such as photo galleries, single session games, or informational frames. These frames could have no use for authentication, they could implement an optional logged in experience (data tracking, saving sessions, etc.), or they could implement a requirement for an authenticated session.

1.) This spec allows Frames that do not require or optionally require authentication to be displayed across any client application that supports Open Frames, regardless of whether the application has a user logged into a session of a client protocol
2.) A frame that is designed to work with one client protocol can more easily be adapted to support other protocols by designating itself as optional
3.) Apps could introduce settings letting users specify to only interact with unauthenticated/optional frames to preserve privacy
4.) Removing unecessary signing and verifying of frame requests reduces latency

## Isn't it always beneficial to use authenticated frame requests when possible?

Not really. Frame requests are not explicitly signed by the user. They are signed and sent in the background by the client application. The only clear advantage to using an authenticated request is that the frame server can verify the identity of a user performing the action is logged into a valid session for `$client_protocol`. The exact details of the request (button pressed, input text, etc.) are placing a similar level of trust in the client application as `untrustedData`.