### PR TITLE
feat: add signature action to tx button spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Here is an example of a POST payload to an unauthenticated Frame Server:
     "inputText": "...",
     "state": "...",
     "address": "0x...",
-    "transaction_id": "0x..."
+    "actionResponse": "0x..."
   }
 }
 ```
@@ -285,7 +285,7 @@ type FramesPost = {
     inputText?: string; // Input text for the Frame's text input, if present. Undefined if no text input field is present
     state?: string; // State that was passed from the frame, passed back to the frame, serialized to a string. Max 4kB.q
     address?: string // Address of connected wallet
-    transaction_id?: string // Transaction hash or signed typed data from wallet action
+    actionResponse?: string // Transaction hash or signed typed data from wallet action
   };
   trustedData: {
     messageBytes: string;

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The client uses the response data to request an action in the user's wallet. If 
 
 A wallet action response must be one of the following:
 
-### EthSendTransactionAction
+**EthSendTransactionAction**
+
     - `chainId`: A CAIP-2 chain ID to identify the transaction network (e.g., Ethereum mainnet).
     - `method`: Must be `"eth_sendTransaction"`.
     - `params`:
@@ -95,7 +96,7 @@ A wallet action response must be one of the following:
         - `value`: Value to send with the transaction in wei (optional).
         - `data`: Transaction calldata (optional).
 
-```
+```tsx
 type EthSendTransactionAction = {
   chainId: string;
   method: 'eth_sendTransaction';
@@ -110,7 +111,7 @@ type EthSendTransactionAction = {
 
 Example:
 
-```
+```json
 {
   "chainId": "eip155:1",
   "method": "eth_sendTransaction",
@@ -123,7 +124,7 @@ Example:
 }
 ```
 
-### EthSignTypedDataV4Action
+**EthSignTypedDataV4Action**
 
 See [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
 
@@ -135,7 +136,7 @@ See [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
         - `primaryType`: The primary type to extract from types and use in value.
         - `message`: Typed message.
 
-```
+```tsx
 type EthSignTypedDataV4Action = {
   chainId: string;
   method: 'eth_signTypedData_v4';
@@ -155,7 +156,7 @@ type EthSignTypedDataV4Action = {
 
 Example:
 
-```
+```json
 {
   "chainId": "eip155:10",
   "method": "eth_signTypedData_v4",
@@ -252,7 +253,7 @@ Clients sending POST requests to an unauthenticated Frame Server should include 
 
 Here is an example of a POST payload to an unauthenticated Frame Server:
 
-```
+```json
 {
   "clientProtocol": "anonymous@1.0",
   "untrustedData": {
@@ -261,7 +262,7 @@ Here is an example of a POST payload to an unauthenticated Frame Server:
     "buttonIndex": 1,
     "inputText": "...",
     "state": "...",
-    "address: "0x...",
+    "address": "0x...",
     "transaction_id": "0x..."
   }
 }
@@ -283,8 +284,8 @@ type FramesPost = {
     buttonIndex: number; // The button that was clicked
     inputText?: string; // Input text for the Frame's text input, if present. Undefined if no text input field is present
     state?: string; // State that was passed from the frame, passed back to the frame, serialized to a string. Max 4kB.q
-    transaction_id?: string // Transaction hash or signed typed data from wallet action
     address?: string // Address of connected wallet
+    transaction_id?: string // Transaction hash or signed typed data from wallet action
   };
   trustedData: {
     messageBytes: string;

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `tx` action allows a frame to request the user take an action in their conne
 
 First, the client makes a POST request to the `target` URL to fetch data about the wallet action. The frame server receives a signed frame action payload in the POST body, including the address of the connected wallet in the `address` field. The frame server must respond with a `200 OK` and a JSON response describing the wallet action which satisfies one of the [wallet action response types](#wallet-action-response-types).
 
-The client uses the response data to request an action in the user's wallet. If the user completes the action, the client makes a POST request to the `post_url` with a signed frame action payload that includes the transaction or signature hash in the `actionResponse` field and the address used in the `address` field. The frame server must respond with a `200 OK` and another frame. The frame server may monitor the transaction hash to determine if the transaction succeeds, reverts, or times out.
+The client uses the response data to request an action in the user's wallet. If the user completes the action, the client makes a POST request to the `post_url` with a signed frame action payload that includes the transaction or signature hash in the `transactionId` field and the address used in the `address` field. The frame server must respond with a `200 OK` and another frame. The frame server may monitor the transaction hash to determine if the transaction succeeds, reverts, or times out.
 
 ### Wallet Action Response Types
 
@@ -263,7 +263,7 @@ Here is an example of a POST payload to an unauthenticated Frame Server:
     "inputText": "...",
     "state": "...",
     "address": "0x...",
-    "actionResponse": "0x..."
+    "transactionId": "0x..."
   }
 }
 ```
@@ -285,7 +285,7 @@ type FramesPost = {
     inputText?: string; // Input text for the Frame's text input, if present. Undefined if no text input field is present
     state?: string; // State that was passed from the frame, passed back to the frame, serialized to a string. Max 4kB.q
     address?: string // Address of connected wallet
-    actionResponse?: string // Transaction hash or signed typed data from wallet action
+    transactionId?: string // Transaction hash or signed typed data from wallet action
   };
   trustedData: {
     messageBytes: string;

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The target property must be a valid [CAIP-10](https://github.com/ChainAgnostic/C
 
 The `tx` action allows a frame to request the user take an action in their connected wallet. Unlike other action types, `tx` actions have multiple steps.
 
-First, the client makes a POST request to the `target` URL to fetch data about the wallet action. The frame server receives a signed frame action payload in the POST body, including the address of the connected wallet in the `address` field. The frame server must respond with a `200 OK` and a JSON response describing the wallet action which satisfies one of the [wallet action response types].
+First, the client makes a POST request to the `target` URL to fetch data about the wallet action. The frame server receives a signed frame action payload in the POST body, including the address of the connected wallet in the `address` field. The frame server must respond with a `200 OK` and a JSON response describing the wallet action which satisfies one of the [wallet action response types](#wallet-action-response-types).
 
 The client uses the response data to request an action in the user's wallet. If the user completes the action, the client makes a POST request to the `post_url` with a signed frame action payload that includes the transaction or signature hash in the `actionResponse` field and the address used in the `address` field. The frame server must respond with a `200 OK` and another frame. The frame server may monitor the transaction hash to determine if the transaction succeeds, reverts, or times out.
 

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ A wallet action response must be one of the following:
 
 **EthSendTransactionAction**
 
-    - `chainId`: A CAIP-2 chain ID to identify the transaction network (e.g., Ethereum mainnet).
-    - `method`: Must be `"eth_sendTransaction"`.
-    - `params`:
-        - `abi`: JSON ABI which MUST include encoded function type and SHOULD include potential error types. Can be empty.
-        - `to`: Transaction recipient.
-        - `value`: Value to send with the transaction in wei (optional).
-        - `data`: Transaction calldata (optional).
+- `chainId`: A CAIP-2 chain ID to identify the transaction network (e.g., Ethereum mainnet).
+- `method`: Must be `"eth_sendTransaction"`.
+- `params`:
+    - `abi`: JSON ABI which MUST include encoded function type and SHOULD include potential error types. Can be empty.
+    - `to`: Transaction recipient.
+    - `value`: Value to send with the transaction in wei (optional).
+    - `data`: Transaction calldata (optional).
 
 ```tsx
 type EthSendTransactionAction = {
@@ -128,13 +128,13 @@ Example:
 
 See [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
 
-    - `chainId`: A CAIP-2 chain ID to identify the transaction network (e.g., Ethereum mainnet).
-    - `method`: Must be `"eth_signTypedData_v4"`.
-    - `params`:
-        - `domain`: The typed domain.
-        - `types`: The type definitions for the typed data.
-        - `primaryType`: The primary type to extract from types and use in value.
-        - `message`: Typed message.
+- `chainId`: A CAIP-2 chain ID to identify the transaction network (e.g., Ethereum mainnet).
+- `method`: Must be `"eth_signTypedData_v4"`.
+- `params`:
+    - `domain`: The typed domain.
+    - `types`: The type definitions for the typed data.
+    - `primaryType`: The primary type to extract from types and use in value.
+    - `message`: Typed message.
 
 ```tsx
 type EthSignTypedDataV4Action = {


### PR DESCRIPTION
Add documentation for signature frames as an extension of `tx` button action.

Additionally, this PR adds two additional fields to `untrustedData` payload which are used in the `tx` button lifecycle:
- `address` : connected wallet address
- `transactionId` : transaction hash or signed typed data